### PR TITLE
Circumvents gradle leak

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -6,7 +6,7 @@ import io.deepmedia.tools.publisher.sonatype.Sonatype
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("io.deepmedia.tools.publisher")
+//    id("io.deepmedia.tools.publisher")
 }
 
 android {
@@ -33,6 +33,7 @@ dependencies {
     androidTestImplementation("org.mockito:mockito-android:2.28.2")
 }
 
+/*
 publisher {
     project.description = "Accelerated video transcoding using Android MediaCodec API without native code (no LGPL/patent issues)."
     project.artifact = "transcoder"
@@ -62,3 +63,4 @@ publisher {
         signing.password = "SIGNING_PASSWORD"
     }
 }
+*/


### PR DESCRIPTION
`io.deepmedia.tools.publisher` was the culprit of the huge gradle leak :)