### PR TITLE
added stream create/destroy support in audio resampler

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/AudioEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/audio/AudioEngine.kt
@@ -53,12 +53,14 @@ class AudioEngine(
         this.rawFormat = rawFormat
         remixer = AudioRemixer[rawFormat.channels, targetFormat.channels]
         chunks = ChunkQueue(rawFormat.sampleRate, rawFormat.channels)
+        resampler.createStream(rawFormat.sampleRate, targetFormat.sampleRate, targetFormat.channels)
     }
 
     override fun enqueueEos(data: DecoderData) {
         log.i("enqueueEos()")
         data.release(false)
         chunks.enqueueEos()
+        resampler.destroyStream()
     }
 
     override fun enqueue(data: DecoderData) {

--- a/lib/src/main/java/com/otaliastudios/transcoder/resample/AudioResampler.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/resample/AudioResampler.java
@@ -22,6 +22,17 @@ public interface AudioResampler {
      */
     void resample(@NonNull final ShortBuffer inputBuffer, int inputSampleRate, @NonNull final ShortBuffer outputBuffer, int outputSampleRate, int channels);
 
+    /**
+     * createStream() and destroyStream() only to be implemented on Resamplers
+     * following a stream approach for continuous input buffers. Not for static one shot methods
+     * to resample.
+     * @param inputSampleRate the input sample rate
+     * @param outputSampleRate the output sample rate
+     * @param numChannels the number of channels
+     */
+    void createStream(int inputSampleRate, int outputSampleRate, int numChannels);
+    void destroyStream();
+
     AudioResampler DOWNSAMPLE = new DownsampleAudioResampler();
 
     AudioResampler UPSAMPLE = new UpsampleAudioResampler();

--- a/lib/src/main/java/com/otaliastudios/transcoder/resample/DefaultAudioResampler.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/resample/DefaultAudioResampler.java
@@ -20,4 +20,14 @@ public class DefaultAudioResampler implements AudioResampler {
             PASSTHROUGH.resample(inputBuffer, inputSampleRate, outputBuffer, outputSampleRate, channels);
         }
     }
+
+    @Override
+    public void createStream(int inputSampleRate, int outputSampleRate, int numChannels) {
+        // do nothing
+    }
+
+    @Override
+    public void destroyStream() {
+        // do nothing
+    }
 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/resample/DownsampleAudioResampler.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/resample/DownsampleAudioResampler.java
@@ -44,4 +44,14 @@ public class DownsampleAudioResampler implements AudioResampler {
             }
         }
     }
+
+    @Override
+    public void createStream(int inputSampleRate, int outputSampleRate, int numChannels) {
+        // do nothing
+    }
+
+    @Override
+    public void destroyStream() {
+        // do nothing
+    }
 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/resample/PassThroughAudioResampler.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/resample/PassThroughAudioResampler.java
@@ -18,4 +18,14 @@ public class PassThroughAudioResampler implements AudioResampler {
         }
         outputBuffer.put(inputBuffer);
     }
+
+    @Override
+    public void createStream(int inputSampleRate, int outputSampleRate, int numChannels) {
+        // do nothing
+    }
+
+    @Override
+    public void destroyStream() {
+        // do nothing
+    }
 }

--- a/lib/src/main/java/com/otaliastudios/transcoder/resample/UpsampleAudioResampler.java
+++ b/lib/src/main/java/com/otaliastudios/transcoder/resample/UpsampleAudioResampler.java
@@ -45,6 +45,16 @@ public class UpsampleAudioResampler implements AudioResampler {
         }
     }
 
+    @Override
+    public void createStream(int inputSampleRate, int outputSampleRate, int numChannels) {
+        // do nothing
+    }
+
+    @Override
+    public void destroyStream() {
+        // do nothing
+    }
+
     /**
      * We have different options here.
      * 1. Return a 0 sample.


### PR DESCRIPTION
The added support is obsolete for otalia's resamplers coz they rely on one shot (method based) resampling