### PR TITLE
maintain requests which are not processed

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/DefaultThumbnailsEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/DefaultThumbnailsEngine.kt
@@ -322,6 +322,9 @@ class DefaultThumbnailsEngine(
             stubs.removeAll {
                 it.request.sourceId() == sourceId
             }
+            pendingRequests.removeAll {
+                it.sourceId() == sourceId
+            }
 //            if (activeStub != null) {
 //                stubs.addFirst(activeStub)
 //            }
@@ -344,6 +347,16 @@ class DefaultThumbnailsEngine(
                 log.i("removePosition Match: $positionUs :$stubs")
                 stubs.remove(stub)
                 shouldSeek = true
+            }
+            val request = pendingRequests.find { it.sourceId() == sourceId && locatedTimestampUs == positionUs }
+            request?.let {
+                pendingRequests.remove(it)
+            }
+        }
+        else {
+            val request = pendingRequests.find { it.sourceId() == sourceId && it.locate(Long.MAX_VALUE)[0] == positionUs }
+            request?.let {
+                pendingRequests.remove(it)
             }
         }
     }

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/ThumbnailsEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/ThumbnailsEngine.kt
@@ -18,7 +18,7 @@ abstract class ThumbnailsEngine {
 
     abstract fun removeDataSource(dataSourceId: String)
 
-    abstract fun updateDataSources(dataSources: List<DataSource>)
+    abstract suspend fun updateDataSources(dataSources: List<DataSource>)
 
     abstract suspend fun queueThumbnails(list: List<ThumbnailRequest>)
 


### PR DESCRIPTION
maintain requests which are not processed due to unavailability of datasources and execute later