### PR TITLE
Feat/transcoder event listener

### DIFF
--- a/lib/src/main/java/com/otaliastudios/transcoder/ThumbnailerOptions.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/ThumbnailerOptions.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import com.otaliastudios.transcoder.internal.codec.TranscoderEventsListener
 import com.otaliastudios.transcoder.internal.thumbnails.ThumbnailsEngine
 import com.otaliastudios.transcoder.resize.ExactResizer
 import com.otaliastudios.transcoder.resize.MultiResizer
@@ -24,7 +25,8 @@ class ThumbnailerOptions(
     val rotation: Int,
     val thumbnailRequests: List<ThumbnailRequest>,
     val listener: ThumbnailerListener?,
-    val listenerHandler: Handler
+    val listenerHandler: Handler,
+    val eventListener: TranscoderEventsListener?,
 ) {
 
     class Builder {
@@ -36,6 +38,7 @@ class ThumbnailerOptions(
         private var rotation = 0
         private var listener: ThumbnailerListener? = null
         private var listenerHandler: Handler? = null
+        private var eventListener: TranscoderEventsListener? = null
 
         fun addDataSource(dataSource: DataSource) = this.also {
             dataSources.add(dataSource)
@@ -82,6 +85,9 @@ class ThumbnailerOptions(
         fun setListener(listener: ThumbnailerListener) = this.also {
             this.listener = listener
         }
+        fun setEventListener(listener: TranscoderEventsListener) = this.also {
+            this.eventListener = listener
+        }
 
         fun build(): ThumbnailerOptions {
 //            require(dataSources.isNotEmpty()) {
@@ -97,7 +103,8 @@ class ThumbnailerOptions(
                 rotation = rotation,
                 thumbnailRequests = thumbnailRequests.toList(),
                 listener = listener,
-                listenerHandler = listenerHandler
+                listenerHandler = listenerHandler,
+                eventListener = eventListener
             )
         }
 

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/TranscoderEventsListener.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/codec/TranscoderEventsListener.kt
@@ -1,0 +1,13 @@
+package com.otaliastudios.transcoder.internal.codec
+
+import android.media.MediaFormat
+
+interface TranscoderEventsListener {
+
+    fun onDecoderConfigureFailure(codecName: String, format: MediaFormat, exception: Exception)
+
+    fun onDecoderStartFailure(codecName: String, format: MediaFormat, exception: Exception)
+
+    fun onDecoderReleaseFailure(codecName: String, format: MediaFormat, exception: Exception)
+
+}

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/DefaultThumbnailsEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/DefaultThumbnailsEngine.kt
@@ -290,7 +290,7 @@ class DefaultThumbnailsEngine(
                     }
                     throw e
                 }
-            } catch (e: IllegalStateException) {
+            } catch (e: Exception) {
                 val path = stub?.request?.sourcePath()
                 if (path != null) {
                     val dataSource = getDataSourceByPath(path)

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/DefaultThumbnailsEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/DefaultThumbnailsEngine.kt
@@ -8,6 +8,7 @@ import com.otaliastudios.transcoder.internal.CustomSegments
 import com.otaliastudios.transcoder.internal.DataSources
 import com.otaliastudios.transcoder.internal.Tracks
 import com.otaliastudios.transcoder.internal.codec.Decoder
+import com.otaliastudios.transcoder.internal.codec.TranscoderEventsListener
 import com.otaliastudios.transcoder.internal.data.Reader
 import com.otaliastudios.transcoder.internal.data.Seeker
 import com.otaliastudios.transcoder.internal.pipeline.Pipeline
@@ -36,7 +37,8 @@ import java.util.ArrayList
 class DefaultThumbnailsEngine(
     private val dataSources: DataSources,
     private val rotation: Int,
-    resizer: Resizer
+    resizer: Resizer,
+    private val eventListener: TranscoderEventsListener?
 ) : ThumbnailsEngine() {
 
     private var shouldSeek = true
@@ -146,7 +148,7 @@ class DefaultThumbnailsEngine(
                 Pair(seekUs, seek)
             } +
                 Reader(source, type) +
-                Decoder(source.getTrackFormat(type)!!, continuous = false, useSwFor4K = true) {
+                Decoder(source.getTrackFormat(type)!!, continuous = false, useSwFor4K = true, eventListener) {
                     shouldFlush.also {
                         shouldFlush = false
                     }
@@ -311,8 +313,8 @@ class DefaultThumbnailsEngine(
                 if (!hasMoreRequestsIncoming) {
                     try {
                         segments.release()
-                    }
-                    catch (_: IllegalStateException) {
+                    } catch (e: IllegalStateException) {
+
                     }
                 }
                 break

--- a/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/ThumbnailsEngine.kt
+++ b/lib/src/main/java/com/otaliastudios/transcoder/internal/thumbnails/ThumbnailsEngine.kt
@@ -52,7 +52,8 @@ abstract class ThumbnailsEngine {
             val engine = DefaultThumbnailsEngine(
                 dataSources = DataSources(options),
                 rotation = options.rotation,
-                resizer = options.resizer
+                resizer = options.resizer,
+                eventListener = options.eventListener
             )
             return engine
         }


### PR DESCRIPTION
Log Exceptions in decoder at 
configure
start
stop & release calls.

information logged at this state is the codec name, media format, and the exception itself. 